### PR TITLE
tpm random emulation workaround

### DIFF
--- a/tpm.go
+++ b/tpm.go
@@ -68,7 +68,13 @@ func GetPubHash(opts ...Option) (string, error) {
 	return hash, nil
 }
 
+var tpm *attest.TPM
+
 func getTPM(c *config) (*attest.TPM, error) {
+
+	if tpm != nil {
+		return tpm, nil
+	}
 
 	cfg := &attest.OpenConfig{
 		TPMVersion: attest.TPMVersion20,
@@ -91,8 +97,9 @@ func getTPM(c *config) (*attest.TPM, error) {
 		cfg.CommandChannel = backend.Fake(sim)
 	}
 
-	return attest.OpenTPM(cfg)
-
+	var err error
+	tpm, err = attest.OpenTPM(cfg)
+	return tpm, err
 }
 
 func getEK(c *config) (*attest.EK, error) {
@@ -102,7 +109,6 @@ func getEK(c *config) (*attest.EK, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening tpm for decoding EK: %w", err)
 	}
-	defer tpm.Close()
 
 	eks, err := tpm.EKs()
 	if err != nil {
@@ -132,7 +138,6 @@ func getAttestationData(c *config) (*AttestationData, []byte, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening tpm for getting attestation data: %w", err)
 	}
-	defer tpm.Close()
 
 	eks, err := tpm.EKs()
 	if err != nil {


### PR DESCRIPTION
When using random emulation, having a seed of 0 will allow to have the emulated TPM keys to be randomly generated and derived independently.

Unfortunately, we open and close the TPM channel each time we want to access it: we end up calling getTPM() multiple times during attestation.

This will work with real TPM chips as the Endorsment Key (EK) will stay the same. Same will be for emulated TPM with a fixed seed (the seed will derive always the same EK). But for random TPM simulator, i.e. a seed of 0, this means that during the attestation we will end up changing the EK during different steps. So, the attestation cannot be successful.

Proper fix is an architectural one: we need to expose API to explicitly open and close access to the TPM device (real or simulated).

This PR workarounds the issue by never closing the tpm device BUT when we call getChallengeResponse(). This is just an ugly workaround to serve the specific case where the operations on the TPM are the one expected for attestation, ended by a call to the Get() or the Authenticate() APIs.
It likely breaks other use cases (for this reason one of the tests doesn't pass). So, more a PoC than a mergeable PR.